### PR TITLE
Added an aggregate operator without a seed

### DIFF
--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -3788,6 +3788,102 @@ namespace cpplinq
         };
 
         // -------------------------------------------------------------------------
+
+        template<typename TPredicate>
+        struct last_predicate_builder : base_builder
+        {
+            typedef                 last_predicate_builder<TPredicate>     this_type           ;
+            typedef                 TPredicate                              predicate_type      ;
+
+            predicate_type          predicate   ;
+
+            CPPLINQ_INLINEMETHOD last_predicate_builder (predicate_type predicate) CPPLINQ_NOEXCEPT
+                :   predicate (std::move (predicate))
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD last_predicate_builder (last_predicate_builder const & v) CPPLINQ_NOEXCEPT
+                :   predicate (v.predicate)
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD last_predicate_builder (last_predicate_builder && v) CPPLINQ_NOEXCEPT
+                : predicate (std::move (v.predicate))
+            {
+            }
+
+            template<typename TRange>
+            CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
+            {
+				bool found = false;
+
+                auto current = typename TRange::value_type ();
+
+                while (range.next ())
+                {
+                    if (predicate (range.front ()))
+                    {
+						found = true;
+                        current = std::move (range.front ());
+                    }
+                }
+
+				if (found)
+				{
+					return current;
+				}
+				else
+				{
+					throw sequence_empty_exception ();
+				}
+            }
+
+        };
+
+        // -------------------------------------------------------------------------
+
+        struct last_builder : base_builder
+        {
+            typedef                 last_builder                   this_type       ;
+
+            CPPLINQ_INLINEMETHOD last_builder () CPPLINQ_NOEXCEPT
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD last_builder (last_builder const & v) CPPLINQ_NOEXCEPT
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD last_builder (last_builder && v) CPPLINQ_NOEXCEPT
+            {
+            }
+
+            template<typename TRange>
+            CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
+            {
+				bool found = false;
+
+                auto current = typename TRange::value_type ();
+
+                while (range.next ())
+                {
+					found = true;
+					current = std::move (range.front ());
+                }
+
+				if (found)
+				{
+					return current;
+				}
+				else
+				{
+					throw sequence_empty_exception ();
+				}
+            }
+
+        };
+
+        // -------------------------------------------------------------------------
         template<typename TPredicate>
         struct last_or_default_predicate_builder : base_builder
         {
@@ -4275,7 +4371,7 @@ namespace cpplinq
             }
 
             template<typename TRange>
-            CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range) const
+            CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
 				if (!range.next ())
 				{
@@ -4322,7 +4418,7 @@ namespace cpplinq
             }
 
             template<typename TRange>
-            CPPLINQ_INLINEMETHOD typename get_transformed_type<result_selector_type, typename TRange::value_type>::type build (TRange range) const
+            CPPLINQ_INLINEMETHOD typename get_transformed_type<result_selector_type, typename TRange::value_type>::type build (TRange range)
             {
 				if (!range.next ())
 				{
@@ -5434,6 +5530,19 @@ namespace cpplinq
         ) CPPLINQ_NOEXCEPT
     {
         return detail::last_or_default_predicate_builder<TPredicate> (predicate);
+    }
+
+    template <typename TPredicate>
+    CPPLINQ_INLINEMETHOD detail::last_predicate_builder<TPredicate> last (
+            TPredicate predicate
+        )
+    {
+        return detail::last_predicate_builder<TPredicate> (std::move (predicate));
+    }
+
+    CPPLINQ_INLINEMETHOD detail::last_builder last ()
+    {
+        return detail::last_builder ();
     }
 
     CPPLINQ_INLINEMETHOD detail::last_or_default_builder last_or_default () CPPLINQ_NOEXCEPT

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -2477,6 +2477,108 @@ namespace cpplinq
 
         // -------------------------------------------------------------------------
 
+        template<typename TRange, typename TSelector>
+        struct distinct_key_selector_range : base_range
+        {
+            typedef             distinct_key_selector_range<TRange, TSelector>      this_type           ;
+            typedef             TRange                                              range_type          ;
+            typedef             TSelector                                           key_selector_type   ;
+
+            typedef    typename cleanup_type<typename TRange::value_type>::type     value_type          ;
+            typedef             value_type const &                                  return_type         ;
+            enum
+            {
+                returns_reference   = 1 ,
+            };
+
+            typedef    typename get_transformed_type<key_selector_type, typename TRange::value_type>::type      key_type                ;
+            typedef             std::set<key_type>                                                              set_type                ;
+
+            range_type                  range               ;
+            key_selector_type           key_selector        ;
+            set_type                    set                 ;
+
+            CPPLINQ_INLINEMETHOD distinct_key_selector_range (
+                        range_type          range
+                    ,   key_selector_type   key_selector
+                ) CPPLINQ_NOEXCEPT
+                :   range               (std::move (range))
+                ,   key_selector        (std::move (key_selector))
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD distinct_key_selector_range (distinct_key_selector_range const & v) CPPLINQ_NOEXCEPT
+                :   range               (v.range)
+                ,   key_selector        (v.key_selector)
+                ,   set                 (v.set)
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD distinct_key_selector_range (distinct_key_selector_range && v) CPPLINQ_NOEXCEPT
+                :   range               (std::move (v.range))
+                ,   key_selector        (std::move (v.key_selector))
+                ,   set                 (std::move (v.set))
+            {
+            }
+
+            template<typename TRangeBuilder>
+            CPPLINQ_INLINEMETHOD typename get_builtup_type<TRangeBuilder, this_type>::type operator>>(TRangeBuilder range_builder) const
+            {
+                return range_builder.build (*this);
+            }
+
+            CPPLINQ_INLINEMETHOD return_type front () const
+            {
+                return range.front ();
+            }
+
+            CPPLINQ_INLINEMETHOD bool next ()
+            {
+                while (range.next ())
+                {
+                    auto result = set.insert (key_selector (range.front ()));
+                    if (result.second)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        };
+
+        template <typename TSelector>
+        struct distinct_key_selector_builder : base_builder
+        {
+            typedef             distinct_key_selector_builder<TSelector>                    this_type           ;
+            typedef             TSelector                                                   key_selector_type   ;
+
+            key_selector_type       key_selector;
+
+            CPPLINQ_INLINEMETHOD distinct_key_selector_builder (key_selector_type key_selector) CPPLINQ_NOEXCEPT
+                :   key_selector (std::move (key_selector))
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD distinct_key_selector_builder (distinct_key_selector_builder const & v) CPPLINQ_NOEXCEPT
+                :   key_selector (v.key_selector)
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD distinct_key_selector_builder (distinct_key_selector_builder && v) CPPLINQ_NOEXCEPT
+                :   key_selector (std::move (v.key_selector))
+            {
+            }
+
+            template<typename TRange>
+            CPPLINQ_INLINEMETHOD distinct_key_selector_range<TRange, TSelector> build (TRange range) const
+            {
+                return distinct_key_selector_range<TRange, TSelector> (std::move (range), key_selector);
+            }
+        };
+
+        // -------------------------------------------------------------------------
+
         template<typename TRange, typename TOtherRange>
         struct union_range : base_range
         {
@@ -3815,7 +3917,7 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-				bool found = false;
+                bool found = false;
 
                 auto current = typename TRange::value_type ();
 
@@ -3823,19 +3925,19 @@ namespace cpplinq
                 {
                     if (predicate (range.front ()))
                     {
-						found = true;
+                        found = true;
                         current = std::move (range.front ());
                     }
                 }
 
-				if (found)
-				{
-					return current;
-				}
-				else
-				{
-					throw sequence_empty_exception ();
-				}
+                if (found)
+                {
+                    return current;
+                }
+                else
+                {
+                    throw sequence_empty_exception ();
+                }
             }
 
         };
@@ -3861,24 +3963,24 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-				bool found = false;
+                bool found = false;
 
                 auto current = typename TRange::value_type ();
 
                 while (range.next ())
                 {
-					found = true;
-					current = std::move (range.front ());
+                    found = true;
+                    current = std::move (range.front ());
                 }
 
-				if (found)
-				{
-					return current;
-				}
-				else
-				{
-					throw sequence_empty_exception ();
-				}
+                if (found)
+                {
+                    return current;
+                }
+                else
+                {
+                    throw sequence_empty_exception ();
+                }
             }
 
         };
@@ -4345,12 +4447,12 @@ namespace cpplinq
 
         };
 
-		// -------------------------------------------------------------------------
+        // -------------------------------------------------------------------------
 
         template <typename TAccumulator>
         struct reduce_builder : base_builder
         {
-            typedef                 reduce_builder<TAccumulator>					this_type       ;
+            typedef                 reduce_builder<TAccumulator>                    this_type       ;
             typedef                 TAccumulator                                    accumulator_type;
 
             accumulator_type        accumulator;
@@ -4373,10 +4475,10 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-				if (!range.next ())
-				{
-					throw sequence_empty_exception ();
-				}
+                if (!range.next ())
+                {
+                    throw sequence_empty_exception ();
+                }
 
                 auto sum = range.front ();
                 while (range.next ())
@@ -4392,7 +4494,7 @@ namespace cpplinq
         template <typename TAccumulator, typename TSelector>
         struct reduce_result_selector_builder : base_builder
         {
-            typedef                 reduce_result_selector_builder<TAccumulator, TSelector>					this_type       ;
+            typedef                 reduce_result_selector_builder<TAccumulator, TSelector>                 this_type       ;
             typedef                 TAccumulator                                                            accumulator_type;
             typedef                 TSelector                                                               result_selector_type;
 
@@ -4420,10 +4522,10 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename get_transformed_type<result_selector_type, typename TRange::value_type>::type build (TRange range)
             {
-				if (!range.next ())
-				{
-					throw sequence_empty_exception ();
-				}
+                if (!range.next ())
+                {
+                    throw sequence_empty_exception ();
+                }
 
                 auto sum = range.front ();
                 while (range.next ())
@@ -5698,17 +5800,17 @@ namespace cpplinq
         return detail::avg_builder ();
     }
 
-	template <typename TAccumulator>
-	CPPLINQ_INLINEMETHOD detail::reduce_builder<TAccumulator> reduce (
-		TAccumulator accumulator
-		) CPPLINQ_NOEXCEPT
-	{
-		return detail::reduce_builder<TAccumulator> (accumulator);
-	}
+    template <typename TAccumulator>
+    CPPLINQ_INLINEMETHOD detail::reduce_builder<TAccumulator> reduce (
+        TAccumulator accumulator
+        ) CPPLINQ_NOEXCEPT
+    {
+        return detail::reduce_builder<TAccumulator> (accumulator);
+    }
 
     template <typename TAccumulator, typename TSelector>
     CPPLINQ_INLINEMETHOD detail::reduce_result_selector_builder<TAccumulator, TSelector> reduce (
-		    TAccumulator accumulator
+            TAccumulator accumulator
         ,   TSelector result_selector
         ) CPPLINQ_NOEXCEPT
     {
@@ -5738,6 +5840,12 @@ namespace cpplinq
     CPPLINQ_INLINEMETHOD detail::distinct_builder distinct () CPPLINQ_NOEXCEPT
     {
         return detail::distinct_builder ();
+    }
+
+    template <typename TSelector>
+    CPPLINQ_INLINEMETHOD detail::distinct_key_selector_builder<TSelector> distinct (TSelector key_selector) CPPLINQ_NOEXCEPT
+    {
+        return detail::distinct_key_selector_builder<TSelector> (key_selector);
     }
 
     template <typename TOtherRange>

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -4196,15 +4196,13 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-                typedef opt<typename TRange::value_type>    opt_type;
-
-                auto current = opt_type ();
+                opt<typename TRange::value_type>    current;
 
                 while (range.next ())
                 {
                     if (predicate (range.front ()))
                     {
-                        current = opt_type (range.front ());
+                        current = range.front ();
                     }
                 }
 
@@ -4241,13 +4239,11 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-                typedef opt<typename TRange::value_type>    opt_type;
-
-                auto current = opt_type ();
+                opt<typename TRange::value_type>    current;
 
                 while (range.next ())
                 {
-                    current = opt_type (range.front ());
+                    current = range.front ();
                 }
 
                 if (current.has_value ())

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -3498,13 +3498,13 @@ namespace cpplinq
 
         // -------------------------------------------------------------------------
 
-        template<typename KeySelector>
+        template<typename TKeySelector>
         struct to_map_builder : base_builder
         {
-            static KeySelector get_key_selector ();
+            static TKeySelector get_key_selector ();
 
-            typedef                     to_map_builder<KeySelector>   this_type         ;
-            typedef                     KeySelector                   key_selector_type ;
+            typedef                     to_map_builder<TKeySelector>   this_type         ;
+            typedef                     TKeySelector                   key_selector_type ;
 
             key_selector_type          key_selector   ;
 

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -90,6 +90,14 @@ namespace cpplinq
         }
     };
 
+    struct out_of_range_exception : base_exception
+    {
+        virtual const char* what ()  const CPPLINQ_NOEXCEPT
+        {
+            return "out_of_range_exception";
+        }
+    };
+
     // -------------------------------------------------------------------------
 
     // -------------------------------------------------------------------------
@@ -5359,7 +5367,7 @@ namespace cpplinq
                     }
                 }
 
-                throw sequence_empty_exception ();
+                throw out_of_range_exception ();
 
             }
 

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -4723,24 +4723,24 @@ namespace cpplinq
         // -------------------------------------------------------------------------
 
         template <typename TAccumulator>
-        struct reduce_builder : base_builder
+        struct aggregate_without_seed_builder : base_builder
         {
-            typedef                 reduce_builder<TAccumulator>                    this_type       ;
+            typedef                 aggregate_without_seed_builder<TAccumulator>    this_type       ;
             typedef                 TAccumulator                                    accumulator_type;
 
             accumulator_type        accumulator;
 
-            CPPLINQ_INLINEMETHOD reduce_builder (accumulator_type accumulator) CPPLINQ_NOEXCEPT
+            CPPLINQ_INLINEMETHOD aggregate_without_seed_builder (accumulator_type accumulator) CPPLINQ_NOEXCEPT
                 :   accumulator (std::move (accumulator))
             {
             }
 
-            CPPLINQ_INLINEMETHOD reduce_builder (reduce_builder const & v) CPPLINQ_NOEXCEPT
+            CPPLINQ_INLINEMETHOD aggregate_without_seed_builder (aggregate_without_seed_builder const & v) CPPLINQ_NOEXCEPT
                 :   accumulator (v.accumulator)
             {
             }
 
-            CPPLINQ_INLINEMETHOD reduce_builder (reduce_builder && v) CPPLINQ_NOEXCEPT
+            CPPLINQ_INLINEMETHOD aggregate_without_seed_builder (aggregate_without_seed_builder && v) CPPLINQ_NOEXCEPT
                 :   accumulator (std::move (v.accumulator))
             {
             }
@@ -4762,56 +4762,6 @@ namespace cpplinq
             }
 
         };
-
-
-        template <typename TAccumulator, typename TSelector>
-        struct reduce_result_selector_builder : base_builder
-        {
-            typedef                 reduce_result_selector_builder<TAccumulator, TSelector>                 this_type       ;
-            typedef                 TAccumulator                                                            accumulator_type;
-            typedef                 TSelector                                                               result_selector_type;
-
-            accumulator_type        accumulator;
-            result_selector_type    result_selector;
-
-            CPPLINQ_INLINEMETHOD reduce_result_selector_builder(accumulator_type accumulator, result_selector_type result_selector) CPPLINQ_NOEXCEPT
-                :   accumulator     (std::move (accumulator))
-                ,   result_selector (std::move (result_selector))
-            {
-            }
-
-            CPPLINQ_INLINEMETHOD reduce_result_selector_builder(reduce_result_selector_builder const & v) CPPLINQ_NOEXCEPT
-                :   accumulator     (v.accumulator)
-                ,   result_selector (v.result_selector)
-            {
-            }
-
-            CPPLINQ_INLINEMETHOD reduce_result_selector_builder(reduce_result_selector_builder && v) CPPLINQ_NOEXCEPT
-                :   accumulator     (std::move (v.accumulator))
-                ,   result_selector (std::move (v.result_selector))
-            {
-            }
-
-            template<typename TRange>
-            CPPLINQ_INLINEMETHOD typename get_transformed_type<result_selector_type, typename TRange::value_type>::type build (TRange range)
-            {
-                if (!range.next ())
-                {
-                    throw sequence_empty_exception ();
-                }
-
-                auto sum = range.front ();
-                while (range.next ())
-                {
-                    sum = accumulator (sum, range.front ());
-                }
-
-                return result_selector (sum);
-            }
-
-        };
-
-        // -------------------------------------------------------------------------
 
         template <typename TAccumulate, typename TAccumulator>
         struct aggregate_builder : base_builder
@@ -6140,20 +6090,11 @@ namespace cpplinq
     }
 
     template <typename TAccumulator>
-    CPPLINQ_INLINEMETHOD detail::reduce_builder<TAccumulator> reduce (
+    CPPLINQ_INLINEMETHOD detail::aggregate_without_seed_builder<TAccumulator> aggregate (
         TAccumulator accumulator
         ) CPPLINQ_NOEXCEPT
     {
-        return detail::reduce_builder<TAccumulator> (accumulator);
-    }
-
-    template <typename TAccumulator, typename TSelector>
-    CPPLINQ_INLINEMETHOD detail::reduce_result_selector_builder<TAccumulator, TSelector> reduce (
-            TAccumulator accumulator
-        ,   TSelector result_selector
-        ) CPPLINQ_NOEXCEPT
-    {
-        return detail::reduce_result_selector_builder<TAccumulator, TSelector> (accumulator, result_selector);
+        return detail::aggregate_without_seed_builder<TAccumulator> (accumulator);
     }
 
     template <typename TAccumulate, typename TAccumulator>

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -3815,7 +3815,7 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-				bool found = false;
+                bool found = false;
 
                 auto current = typename TRange::value_type ();
 
@@ -3823,19 +3823,19 @@ namespace cpplinq
                 {
                     if (predicate (range.front ()))
                     {
-						found = true;
+                        found = true;
                         current = std::move (range.front ());
                     }
                 }
 
-				if (found)
-				{
-					return current;
-				}
-				else
-				{
-					throw sequence_empty_exception ();
-				}
+                if (found)
+                {
+                    return current;
+                }
+                else
+                {
+                    throw sequence_empty_exception ();
+                }
             }
 
         };
@@ -3861,24 +3861,24 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-				bool found = false;
+                bool found = false;
 
                 auto current = typename TRange::value_type ();
 
                 while (range.next ())
                 {
-					found = true;
-					current = std::move (range.front ());
+                    found = true;
+                    current = std::move (range.front ());
                 }
 
-				if (found)
-				{
-					return current;
-				}
-				else
-				{
-					throw sequence_empty_exception ();
-				}
+                if (found)
+                {
+                    return current;
+                }
+                else
+                {
+                    throw sequence_empty_exception ();
+                }
             }
 
         };
@@ -4345,7 +4345,7 @@ namespace cpplinq
 
         };
 
-		// -------------------------------------------------------------------------
+        // -------------------------------------------------------------------------
 
         template <typename TAccumulator>
         struct reduce_builder : base_builder
@@ -4373,10 +4373,10 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-				if (!range.next ())
-				{
-					throw sequence_empty_exception ();
-				}
+                if (!range.next ())
+                {
+                    throw sequence_empty_exception ();
+                }
 
                 auto sum = range.front ();
                 while (range.next ())
@@ -4420,10 +4420,10 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename get_transformed_type<result_selector_type, typename TRange::value_type>::type build (TRange range)
             {
-				if (!range.next ())
-				{
-					throw sequence_empty_exception ();
-				}
+                if (!range.next ())
+                {
+                    throw sequence_empty_exception ();
+                }
 
                 auto sum = range.front ();
                 while (range.next ())
@@ -4942,6 +4942,53 @@ namespace cpplinq
                 }
 
                 return typename TRange::value_type ();
+
+            }
+
+        };
+
+        // -------------------------------------------------------------------------
+
+        struct element_at_builder : base_builder
+        {
+            typedef                 element_at_builder   this_type       ;
+
+            size_type               index;
+
+            CPPLINQ_INLINEMETHOD element_at_builder (size_type index) CPPLINQ_NOEXCEPT
+                :   index (std::move (index))
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD element_at_builder (element_at_builder const & v) CPPLINQ_NOEXCEPT
+                :   index (v.index)
+            {
+            }
+
+            CPPLINQ_INLINEMETHOD element_at_builder (element_at_builder && v) CPPLINQ_NOEXCEPT
+                :   index (std::move (v.index))
+            {
+            }
+
+
+            template<typename TRange>
+            CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
+            {
+                size_type current = 0U;
+
+                while (range.next ())
+                {
+                    if (current < index)
+                    {
+                        ++current;
+                    }
+                    else
+                    {
+                        return range.front ();
+                    }
+                }
+
+                throw sequence_empty_exception ();
 
             }
 
@@ -5550,6 +5597,13 @@ namespace cpplinq
         return detail::last_or_default_builder ();
     }
 
+    CPPLINQ_INLINEMETHOD detail::element_at_builder element_at (
+            size_type   index
+        ) CPPLINQ_NOEXCEPT
+    {
+        return detail::element_at_builder (index);
+    }
+
     CPPLINQ_INLINEMETHOD detail::element_at_or_default_builder element_at_or_default (
             size_type   index
         ) CPPLINQ_NOEXCEPT
@@ -5698,17 +5752,17 @@ namespace cpplinq
         return detail::avg_builder ();
     }
 
-	template <typename TAccumulator>
-	CPPLINQ_INLINEMETHOD detail::reduce_builder<TAccumulator> reduce (
-		TAccumulator accumulator
-		) CPPLINQ_NOEXCEPT
-	{
-		return detail::reduce_builder<TAccumulator> (accumulator);
-	}
+    template <typename TAccumulator>
+    CPPLINQ_INLINEMETHOD detail::reduce_builder<TAccumulator> reduce (
+        TAccumulator accumulator
+        ) CPPLINQ_NOEXCEPT
+    {
+        return detail::reduce_builder<TAccumulator> (accumulator);
+    }
 
     template <typename TAccumulator, typename TSelector>
     CPPLINQ_INLINEMETHOD detail::reduce_result_selector_builder<TAccumulator, TSelector> reduce (
-		    TAccumulator accumulator
+            TAccumulator accumulator
         ,   TSelector result_selector
         ) CPPLINQ_NOEXCEPT
     {

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -4188,22 +4188,21 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-                bool found = false;
+                typedef opt<typename TRange::value_type>    opt_type;
 
-                auto current = typename TRange::value_type ();
+                auto current = opt_type ();
 
                 while (range.next ())
                 {
                     if (predicate (range.front ()))
                     {
-                        found = true;
-                        current = std::move (range.front ());
+                        current = opt_type (range.front ());
                     }
                 }
 
-                if (found)
+                if (current.has_value ())
                 {
-                    return current;
+                    return current.get ();
                 }
                 else
                 {
@@ -4234,19 +4233,18 @@ namespace cpplinq
             template<typename TRange>
             CPPLINQ_INLINEMETHOD typename TRange::value_type build (TRange range)
             {
-                bool found = false;
+                typedef opt<typename TRange::value_type>    opt_type;
 
-                auto current = typename TRange::value_type ();
+                auto current = opt_type ();
 
                 while (range.next ())
                 {
-                    found = true;
-                    current = std::move (range.front ());
+                    current = opt_type (range.front ());
                 }
 
-                if (found)
+                if (current.has_value ())
                 {
-                    return current;
+                    return current.get ();
                 }
                 else
                 {
@@ -4289,7 +4287,7 @@ namespace cpplinq
                 {
                     if (predicate (range.front ()))
                     {
-                        current = std::move (range.front ());
+                        current = range.front ();
                     }
                 }
 
@@ -4321,7 +4319,7 @@ namespace cpplinq
 
                 while (range.next ())
                 {
-                    current = std::move (range.front ());
+                    current = range.front ();
                 }
 
                 return current;

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -2221,6 +2221,73 @@ namespace
         }
     }
 
+    void test_element_at ()
+    {
+        using namespace cpplinq;
+
+        TEST_PRELUDE ();
+
+        std::string expected_on_failure ("sequence_empty_exception");
+
+        {
+			sequence_empty_exception caught_exception;
+			try
+            {
+				auto result = from (empty_vector) >> element_at (0);
+                ignore (result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+        {
+			sequence_empty_exception caught_exception;
+			try
+            {
+				auto result = from (empty_vector) >> element_at (1);
+                ignore (result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+        {
+            auto result = from_array (ints) >> element_at (0);
+            TEST_ASSERT (3, result);
+        }
+
+        {
+            auto result = from_array (ints) >> element_at (1);
+            TEST_ASSERT (1, result);
+        }
+
+        {
+            auto result = from_array (ints) >> element_at (count_of_ints-1);
+            TEST_ASSERT (5, result);
+        }
+
+        {
+			sequence_empty_exception caught_exception;
+			try
+            {
+				auto result = from_array (ints) >> element_at (count_of_ints);
+                ignore (result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+    }
+
     void test_element_at_or_default ()
     {
         using namespace cpplinq;
@@ -2297,7 +2364,7 @@ namespace
             sequence_empty_exception caught_exception;
             try
             {
-				auto reduce_result = from (empty_vector) >> reduce (sum_aggregator, to_string);
+                auto reduce_result = from (empty_vector) >> reduce (sum_aggregator, to_string);
                 ignore (reduce_result);
             }
             catch (sequence_empty_exception const & ex)
@@ -3271,6 +3338,7 @@ namespace
         test_take_while             ();
         test_skip_while             ();
         test_contains               ();
+        test_element_at             ();
         test_element_at_or_default  ();
         test_reduce                 ();
         test_aggregate              ();

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -2198,6 +2198,67 @@ namespace
 
     }
 
+    void test_reduce ()
+    {
+        using namespace cpplinq;
+
+        TEST_PRELUDE ();
+
+        std::string expected_on_failure ("sequence_empty_exception");
+
+        {
+            sequence_empty_exception caught_exception;
+            try
+            {
+                int reduce_result = from (empty_vector) >> reduce (sum_aggregator);
+                ignore (reduce_result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+        {
+            int sum_of_simple_ints = std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 0);
+            int sum_result = from_array (simple_ints) >> reduce (sum_aggregator);
+            TEST_ASSERT (sum_of_simple_ints, sum_result);
+        }
+
+        {
+            int prod_of_simple_ints = std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 1, mul_aggregator);
+            int sum_result = from_array (simple_ints) >> reduce (mul_aggregator);
+            TEST_ASSERT (prod_of_simple_ints, sum_result);
+        }
+
+        {
+            sequence_empty_exception caught_exception;
+            try
+            {
+				auto reduce_result = from (empty_vector) >> reduce (sum_aggregator, to_string);
+                ignore (reduce_result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+        {
+            auto sum_of_simple_ints = to_string (std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 0));
+            auto sum_result = from_array (simple_ints) >> reduce (sum_aggregator, to_string);
+            TEST_ASSERT (sum_of_simple_ints, sum_result);
+        }
+
+        {
+            auto prod_of_simple_ints = to_string (std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 1, mul_aggregator));
+            auto sum_result = from_array (simple_ints) >> reduce (mul_aggregator, to_string);
+            TEST_ASSERT (prod_of_simple_ints, sum_result);
+        }
+    }
+
     void test_aggregate ()
     {
         using namespace cpplinq;
@@ -3149,6 +3210,7 @@ namespace
         test_skip_while             ();
         test_contains               ();
         test_element_at_or_default  ();
+        test_reduce                 ();
         test_aggregate              ();
         test_distinct               ();
         test_union_with             ();

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -235,7 +235,7 @@ namespace
     auto                mul_aggregator          = [](int s, int i) {return s*i;};
     auto                to_string               = [](int i) -> std::string {std::stringstream sstr; sstr<<i; return sstr.str ();};
     auto                modular_of_four         = [](int i) {return i%4;};
-    auto                customer_last_name     = [](customer const & c) {return c.last_name;};
+    auto                customer_last_name      = [](customer const & c) {return c.last_name;};
 
     void print_index (char const * name, std::size_t index)
     {
@@ -550,6 +550,11 @@ namespace
             }
 
             {
+                auto results = lookup.range_of_keys () >> to_vector ();
+                TEST_ASSERT (0U, results.size ());
+            }
+
+            {
                 auto results = lookup.range_of_values () >> to_vector ();
                 TEST_ASSERT (0U, results.size ());
             }
@@ -564,6 +569,23 @@ namespace
 
             TEST_ASSERT (count_of_customers, lookup.size_of_keys ());
             TEST_ASSERT (count_of_customers, lookup.size_of_values ());
+
+            {
+                auto results = lookup.range_of_keys () >> to_vector ();
+                if (TEST_ASSERT (count_of_customers, results.size ()))
+                {
+                    for (std::size_t iter = 0U; iter < count_of_customers; ++iter)
+                    {
+                        // As customers are sorted on id in the test data set
+                        // this is ok
+                        if (!TEST_ASSERT (customers[iter].id, results[iter].first))
+                        {
+                            PRINT_INDEX (iter);
+                        }
+                    }
+                }
+
+            }
 
             {
                 auto results = lookup.range_of_values () >> to_vector ();
@@ -612,9 +634,14 @@ namespace
             TEST_ASSERT (count_of_customer_addresses, lookup.size_of_values ());
 
             {
+                auto results = lookup.range_of_keys () >> to_vector ();
+                TEST_ASSERT (2U, results.size ());
+            }
+            {
                 auto results = lookup.range_of_values () >> to_vector ();
                 TEST_ASSERT (count_of_customer_addresses, results.size ());
             }
+
             {
                 auto results = lookup[1] >> to_vector ();
                 if (TEST_ASSERT (1U, results.size ()))
@@ -633,6 +660,144 @@ namespace
 
                     auto result2 = results[1];
                     TEST_ASSERT (3U, result2.id);
+                }
+            }
+
+            {
+                auto results = lookup[999] >> to_vector ();
+                TEST_ASSERT (0U, results.size ());
+            }
+        }
+
+        {
+            lookup<size_type, std::string> lookup (
+                    16U
+                ,   from (empty_customers)
+                ,   [] (customer const & c){return c.id;}
+                ,   [] (customer const & c){return c.last_name;}
+                );
+
+            TEST_ASSERT (0U, lookup.size_of_keys ());
+            TEST_ASSERT (0U, lookup.size_of_values ());
+
+            {
+                auto results = lookup[999] >> to_vector ();
+                TEST_ASSERT (0U, results.size ());
+            }
+
+            {
+                auto results = lookup.range_of_keys () >> to_vector ();
+                TEST_ASSERT (0U, results.size ());
+            }
+
+            {
+                auto results = lookup.range_of_values () >> to_vector ();
+                TEST_ASSERT (0U, results.size ());
+            }
+        }
+
+        {
+            lookup<size_type, std::string> lookup (
+                    16U
+                ,   from_array (customers)
+                ,   [] (customer const & c){return c.id;}
+                ,   [] (customer const & c){return c.last_name;}
+                );
+
+            TEST_ASSERT (count_of_customers, lookup.size_of_keys ());
+            TEST_ASSERT (count_of_customers, lookup.size_of_values ());
+
+            {
+                auto results = lookup.range_of_keys () >> to_vector ();
+                if (TEST_ASSERT (count_of_customers, results.size ()))
+                {
+                    for (std::size_t iter = 0U; iter < count_of_customers; ++iter)
+                    {
+                        // As customers are sorted on id in the test data set
+                        // this is ok
+                        if (!TEST_ASSERT (customers[iter].id, results[iter].first))
+                        {
+                            PRINT_INDEX (iter);
+                        }
+                    }
+                }
+
+            }
+
+            {
+                auto results = lookup.range_of_values () >> to_vector ();
+                if (TEST_ASSERT (count_of_customers, results.size ()))
+                {
+                    for (std::size_t iter = 0U; iter < count_of_customers; ++iter)
+                    {
+                        // As customers are sorted on id in the test data set
+                        // this is ok
+                        if (!TEST_ASSERT (customers[iter].last_name, results[iter]))
+                        {
+                            PRINT_INDEX (iter);
+                        }
+                    }
+                }
+
+            }
+
+            for (auto customer : customers)
+            {
+                auto results = lookup[customer.id] >> to_vector ();
+                if (TEST_ASSERT (1U, results.size ()))
+                {
+                    auto result = results.front ();
+
+                    if (!TEST_ASSERT (customer.last_name, result))
+                    {
+                        PRINT_INDEX (customer.id);
+                    }
+                }
+                else
+                {
+                    PRINT_INDEX (customer.id);
+                }
+            }
+        }
+
+        {
+            lookup<size_type, std::string> lookup (
+                    16U
+                ,   from_array (customer_addresses)
+                ,   [] (customer_address const & ca){return ca.customer_id;}
+                ,   [] (customer_address const & ca){return ca.country;}
+                );
+
+            TEST_ASSERT (2U, lookup.size_of_keys ());
+            TEST_ASSERT (count_of_customer_addresses, lookup.size_of_values ());
+
+            {
+                auto results = lookup.range_of_keys () >> to_vector ();
+                TEST_ASSERT (2U, results.size ());
+            }
+            {
+                auto results = lookup.range_of_values () >> to_vector ();
+                TEST_ASSERT (count_of_customer_addresses, results.size ());
+            }
+
+            {
+                auto results = lookup[1] >> to_vector ();
+                if (TEST_ASSERT (1U, results.size ()))
+                {
+                    auto result = results.front ();
+                    TEST_ASSERT ("USA", result);
+                }
+            }
+
+            {
+                auto results = lookup[4] >> to_vector ();
+                if (TEST_ASSERT (2U, results.size ()))
+                {
+                    auto result1 = results[0];
+                    TEST_ASSERT ("Finland", result1);
+
+                    auto result2 = results[1];
+                    TEST_ASSERT ("USA", result2);
                 }
             }
 
@@ -1555,6 +1720,81 @@ namespace
         // code coverage test
         {
             auto lookup = empty<int>() >> to_lookup ([] (int i) {return i;});
+
+            auto q = lookup[999];
+
+            TEST_ASSERT (false, q.next ());
+            TEST_ASSERT (false, q.next ());
+        }
+
+        {
+            auto lookup = from (empty_customers) >> to_lookup ([] (customer const & c){return c.id;}, [] (customer const & c){return c.last_name;});
+
+            TEST_ASSERT (0U, lookup.size_of_keys ());
+            TEST_ASSERT (0U, lookup.size_of_values ());
+        }
+
+        {
+            auto lookup = from_array (customers) >> to_lookup ([] (customer const & c){return c.id;}, [] (customer const & c){return c.last_name;});
+
+            TEST_ASSERT (count_of_customers, lookup.size_of_keys ());
+            TEST_ASSERT (count_of_customers, lookup.size_of_values ());
+
+            for (auto customer : customers)
+            {
+                auto results = lookup[customer.id] >> to_vector ();
+                if (TEST_ASSERT (1U, results.size ()))
+                {
+                    auto result = results.front ();
+
+                    if (!TEST_ASSERT (customer.last_name, result))
+                    {
+                        PRINT_INDEX (customer.id);
+                    }
+                }
+                else
+                {
+                    PRINT_INDEX (customer.id);
+                }
+            }
+        }
+
+        {
+            auto lookup = from_array (customer_addresses) >> to_lookup ([] (customer_address const & ca){return ca.customer_id;}, [] (customer_address const & ca){return ca.country;});
+
+            TEST_ASSERT (2U, lookup.size_of_keys ());
+            TEST_ASSERT (count_of_customer_addresses, lookup.size_of_values ());
+
+            {
+                auto results = lookup[1] >> to_vector ();
+                if (TEST_ASSERT (1U, results.size ()))
+                {
+                    auto result = results.front ();
+                    TEST_ASSERT ("USA", result);
+                }
+            }
+
+            {
+                auto results = lookup[4] >> to_vector ();
+                if (TEST_ASSERT (2U, results.size ()))
+                {
+                    auto result1 = results[0];
+                    TEST_ASSERT ("Finland", result1);
+
+                    auto result2 = results[1];
+                    TEST_ASSERT ("USA", result2);
+                }
+            }
+
+            {
+                auto results = lookup[999] >> to_vector ();
+                TEST_ASSERT (0U, results.size ());
+            }
+        }
+
+        // code coverage test
+        {
+            auto lookup = empty<int>() >> to_lookup ([] (int i) {return i;}, [] (int i) {return i;});
 
             auto q = lookup[999];
 

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -2479,16 +2479,16 @@ namespace
 
         TEST_PRELUDE ();
 
-        std::string expected_on_failure ("sequence_empty_exception");
+        std::string expected_on_failure ("out_of_range_exception");
 
         {
-            sequence_empty_exception caught_exception;
+            out_of_range_exception caught_exception;
             try
             {
                 auto result = from (empty_vector) >> element_at (0);
                 ignore (result);
             }
-            catch (sequence_empty_exception const & ex)
+            catch (out_of_range_exception const & ex)
             {
                 caught_exception = ex;
             }
@@ -2496,13 +2496,13 @@ namespace
         }
 
         {
-            sequence_empty_exception caught_exception;
+            out_of_range_exception caught_exception;
             try
             {
                 auto result = from (empty_vector) >> element_at (1);
                 ignore (result);
             }
-            catch (sequence_empty_exception const & ex)
+            catch (out_of_range_exception const & ex)
             {
                 caught_exception = ex;
             }
@@ -2525,13 +2525,13 @@ namespace
         }
 
         {
-            sequence_empty_exception caught_exception;
+            out_of_range_exception caught_exception;
             try
             {
                 auto result = from_array (ints) >> element_at (count_of_ints);
                 ignore (result);
             }
-            catch (sequence_empty_exception const & ex)
+            catch (out_of_range_exception const & ex)
             {
                 caught_exception = ex;
             }

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -1102,6 +1102,67 @@ namespace
 
     }
 
+    void test_last ()
+    {
+        using namespace cpplinq;
+
+        TEST_PRELUDE ();
+
+        std::string expected_on_failure ("sequence_empty_exception");
+
+        {
+            sequence_empty_exception caught_exception;
+            try
+            {
+                int last_result = from (empty_vector) >> last ();
+                ignore (last_result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+        {
+            int last_result = from_array (ints) >> last ();
+            TEST_ASSERT (5, last_result);
+        }
+
+        {
+            sequence_empty_exception caught_exception;
+            try
+            {
+                int last_result = from (empty_vector) >> last (is_even);
+                ignore (last_result);
+            }
+            catch (sequence_empty_exception const & ex)
+            {
+                caught_exception = ex;
+            }
+            TEST_ASSERT (expected_on_failure, caught_exception.what ());
+        }
+
+        {
+            int last_result = from_array (ints) >> last (is_even);
+            TEST_ASSERT (2, last_result);
+        }
+
+        {
+            // Issue: https://cpplinq.codeplex.com/workitem/15
+            // Reported by: Sepidar
+            auto result =
+                    range (0, 4)
+                >>  where ([](int i) {return i % 2 == 1;})
+                >>  orderby ([](int i) {return i;})
+                >>  last ()
+                ;
+
+            TEST_ASSERT (3, result);
+        }
+
+    }
+
     void test_last_or_default ()
     {
         using namespace cpplinq;
@@ -1109,23 +1170,23 @@ namespace
         TEST_PRELUDE ();
 
         {
-            int first_result = from (empty_vector) >> last_or_default ();
-            TEST_ASSERT (0, first_result);
+            int last_result = from (empty_vector) >> last_or_default ();
+            TEST_ASSERT (0, last_result);
         }
 
         {
-            int first_result = from_array (ints) >> last_or_default ();
-            TEST_ASSERT (5, first_result);
+            int last_result = from_array (ints) >> last_or_default ();
+            TEST_ASSERT (5, last_result);
         }
 
         {
-            int first_result = from (empty_vector) >> last_or_default (is_even);
-            TEST_ASSERT (0, first_result);
+            int last_result = from (empty_vector) >> last_or_default (is_even);
+            TEST_ASSERT (0, last_result);
         }
 
         {
-            int first_result = from_array (ints) >> last_or_default (is_even);
-            TEST_ASSERT (2, first_result);
+            int last_result = from_array (ints) >> last_or_default (is_even);
+            TEST_ASSERT (2, last_result);
         }
     }
 
@@ -3184,6 +3245,7 @@ namespace
         test_any                    ();
         test_first                  ();
         test_first_or_default       ();
+        test_last                   ();
         test_last_or_default        ();
         test_sum                    ();
         test_avg                    ();

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -2242,10 +2242,10 @@ namespace
         std::string expected_on_failure ("sequence_empty_exception");
 
         {
-			sequence_empty_exception caught_exception;
-			try
+            sequence_empty_exception caught_exception;
+            try
             {
-				auto result = from (empty_vector) >> element_at (0);
+                auto result = from (empty_vector) >> element_at (0);
                 ignore (result);
             }
             catch (sequence_empty_exception const & ex)
@@ -2256,10 +2256,10 @@ namespace
         }
 
         {
-			sequence_empty_exception caught_exception;
-			try
+            sequence_empty_exception caught_exception;
+            try
             {
-				auto result = from (empty_vector) >> element_at (1);
+                auto result = from (empty_vector) >> element_at (1);
                 ignore (result);
             }
             catch (sequence_empty_exception const & ex)
@@ -2285,10 +2285,10 @@ namespace
         }
 
         {
-			sequence_empty_exception caught_exception;
-			try
+            sequence_empty_exception caught_exception;
+            try
             {
-				auto result = from_array (ints) >> element_at (count_of_ints);
+                auto result = from_array (ints) >> element_at (count_of_ints);
                 ignore (result);
             }
             catch (sequence_empty_exception const & ex)

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -2847,6 +2847,89 @@ namespace
         }
     }
 
+    void test_start_with ()
+    {
+        using namespace cpplinq;
+
+        TEST_PRELUDE ();
+
+        // start_with two empty ranges
+        {
+            auto result = empty<int>() >> start_with (empty<int>()) >> to_vector ();
+            TEST_ASSERT (0U, result.size ());
+        }
+
+        // start_with two empty ranges
+        {
+            auto result = from (empty_vector) >> start_with (empty<int>()) >> to_vector ();
+            TEST_ASSERT (0U, result.size ());
+        }
+
+        // start_with an empty range with a non empty range
+        {
+            auto expected = range (0,10);
+            auto expected_result = expected >> to_vector ();
+            auto result = empty<int>() >> start_with (expected) >> to_vector ();
+            TEST_ASSERT (expected_result.size (), result.size ());
+            for (auto i = 0U; i < expected_result.size () && i < result.size ();++i)
+            {
+                TEST_ASSERT (expected_result[i], result[i]);
+            }
+        }
+
+        // start_with an empty range with a non empty range
+        {
+            auto result = empty<int>() >> start_with (from_array (ints)) >> to_vector ();
+            TEST_ASSERT (count_of_ints, result.size ());
+            for (auto i = 0U; i < count_of_ints && i < result.size ();++i)
+            {
+                TEST_ASSERT (ints[i], result[i]);
+            }
+        }
+
+        // start_with a non empty range with an empty range
+        {
+            auto expected = range (0,10);
+            auto expected_result = expected >> to_vector ();
+            auto result = expected >> start_with (empty<int>()) >> to_vector ();
+            TEST_ASSERT (expected_result.size (), result.size ());
+            for (auto i = 0U; i < expected_result.size () && i < result.size ();++i)
+            {
+                TEST_ASSERT (expected_result[i], result[i]);
+            }
+        }
+
+        // start_with a non empty range with an empty range
+        {
+            auto result = from_array (ints) >> start_with (empty<int>()) >> to_vector ();
+            TEST_ASSERT (count_of_ints, result.size ());
+            for (auto i = 0U; i < count_of_ints && i < result.size ();++i)
+            {
+                TEST_ASSERT (ints[i], result[i]);
+            }
+        }
+
+        // start_with two non-empty ranges
+        {
+            int set1[] = {6,7,8,9};
+            int set2[] = {0,1,2,3,4,5};
+            auto result = from_array (set1) >> start_with (from_array (set2)) >> to_vector ();
+            TEST_ASSERT (10U, result.size ());
+            for (auto i = 0U; i < 10 && i < result.size (); ++i)
+            {
+                TEST_ASSERT (static_cast<int> (i), result[i]);
+            }
+        }
+
+        // code coverage test
+        {
+            auto q = empty<int>() >> start_with (empty<int>());
+
+            TEST_ASSERT (false, q.next ());
+            TEST_ASSERT (false, q.next ());
+        }
+    }
+
     void test_sequence_equal ()
     {
         using namespace cpplinq;
@@ -3383,6 +3466,7 @@ namespace
         test_intersect_with         ();
         test_except                 ();
         test_concat                 ();
+        test_start_with             ();
         test_sequence_equal         ();
         test_pairwise               ();
         test_zip_with               ();

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -2578,7 +2578,7 @@ namespace
 
     }
 
-    void test_reduce ()
+    void test_aggregate ()
     {
         using namespace cpplinq;
 
@@ -2590,8 +2590,8 @@ namespace
             sequence_empty_exception caught_exception;
             try
             {
-                int reduce_result = from (empty_vector) >> reduce (sum_aggregator);
-                ignore (reduce_result);
+                int sum_result = from (empty_vector) >> aggregate (sum_aggregator);
+                ignore (sum_result);
             }
             catch (sequence_empty_exception const & ex)
             {
@@ -2602,48 +2602,15 @@ namespace
 
         {
             int sum_of_simple_ints = std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 0);
-            int sum_result = from_array (simple_ints) >> reduce (sum_aggregator);
+            int sum_result = from_array (simple_ints) >> aggregate (sum_aggregator);
             TEST_ASSERT (sum_of_simple_ints, sum_result);
         }
 
         {
             int prod_of_simple_ints = std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 1, mul_aggregator);
-            int sum_result = from_array (simple_ints) >> reduce (mul_aggregator);
+            int sum_result = from_array (simple_ints) >> aggregate (mul_aggregator);
             TEST_ASSERT (prod_of_simple_ints, sum_result);
         }
-
-        {
-            sequence_empty_exception caught_exception;
-            try
-            {
-                auto reduce_result = from (empty_vector) >> reduce (sum_aggregator, to_string);
-                ignore (reduce_result);
-            }
-            catch (sequence_empty_exception const & ex)
-            {
-                caught_exception = ex;
-            }
-            TEST_ASSERT (expected_on_failure, caught_exception.what ());
-        }
-
-        {
-            auto sum_of_simple_ints = to_string (std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 0));
-            auto sum_result = from_array (simple_ints) >> reduce (sum_aggregator, to_string);
-            TEST_ASSERT (sum_of_simple_ints, sum_result);
-        }
-
-        {
-            auto prod_of_simple_ints = to_string (std::accumulate (simple_ints, simple_ints + count_of_simple_ints, 1, mul_aggregator));
-            auto sum_result = from_array (simple_ints) >> reduce (mul_aggregator, to_string);
-            TEST_ASSERT (prod_of_simple_ints, sum_result);
-        }
-    }
-
-    void test_aggregate ()
-    {
-        using namespace cpplinq;
-
-        TEST_PRELUDE ();
 
         {
             int sum_result = from (empty_vector) >> aggregate (0, sum_aggregator);
@@ -3699,7 +3666,6 @@ namespace
         test_contains               ();
         test_element_at             ();
         test_element_at_or_default  ();
-        test_reduce                 ();
         test_aggregate              ();
         test_distinct               ();
         test_union_with             ();

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -197,6 +197,16 @@ namespace
             customer (12, "Tim"     , "Cook"    ),
         };
 
+    customer const          customers_set3[] =
+        {
+            customer (1 , "Bill"    , "Gates"   ),
+            customer (2 , "Steve"   , "Jobs"    ),
+            customer (3 , "Richard" , "Stallman"),
+            customer (4 , "XXX"     , "Jobs"    ),
+            customer (5 , "XXX"     , "Stallman"),
+            customer (6 , "???"     , "Stallman"),
+        };
+
     int const           ints[]                  = {3,1,4,1,5,9,2,6,5,3,5,8,9,7,9,3,2,3,8,4,6,2,6,4,3,3,8,3,2,7,9,5};
     std::size_t const   count_of_ints           = get_array_size (ints);
 
@@ -224,6 +234,8 @@ namespace
     auto                sum_aggregator          = [](int s, int i) {return s+i;};
     auto                mul_aggregator          = [](int s, int i) {return s*i;};
     auto                to_string               = [](int i) -> std::string {std::stringstream sstr; sstr<<i; return sstr.str ();};
+    auto                modular_of_four         = [](int i) {return i%4;};
+    auto                customer_last_name     = [](customer const & c) {return c.last_name;};
 
     void print_index (char const * name, std::size_t index)
     {
@@ -2297,7 +2309,7 @@ namespace
             sequence_empty_exception caught_exception;
             try
             {
-				auto reduce_result = from (empty_vector) >> reduce (sum_aggregator, to_string);
+                auto reduce_result = from (empty_vector) >> reduce (sum_aggregator, to_string);
                 ignore (reduce_result);
             }
             catch (sequence_empty_exception const & ex)
@@ -2389,6 +2401,30 @@ namespace
         {
             auto d = from_array (customers_set1) >> distinct () >> to_vector ();
             TEST_ASSERT (4U, d.size ());
+        }
+
+        {
+            auto d = from (empty_vector) >> distinct (modular_of_four) >> to_vector ();
+            TEST_ASSERT (0U, d.size ());
+        }
+
+        {
+            int expected[] = {5,4,3,2};
+            auto expected_size = get_array_size (expected);
+
+            auto result = from_array (set1) >> distinct (modular_of_four) >> to_vector ();
+            auto result_size = result.size ();
+
+            TEST_ASSERT (expected_size, result_size);
+            for (auto i = 0U; i < expected_size && i < result_size; ++i)
+            {
+                TEST_ASSERT (expected[i], result[i]);
+            }
+        }
+
+        {
+            auto d = from_array (customers_set3) >> distinct (customer_last_name) >> to_vector ();
+            TEST_ASSERT (3U, d.size ());
         }
 
     }


### PR DESCRIPTION
I've implemented the following operators
aggregate without a seed
last
element_at
distinct with a key selector
start_with
to_lookup with a value selector
