### PR TITLE
cmake package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required (VERSION 3.2.2)
+project (cpplinq)
+
+set (CPPLINQ_VERSION "20150908")
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/CppLinq DESTINATION include
+        FILES_MATCHING PATTERN "*.hpp")
+
+
+include(CMakePackageConfigHelpers)
+set(INCLUDE_INSTALL_DIR include/)
+configure_package_config_file(
+  ${cpplinq_SOURCE_DIR}/cmake/modules/${PROJECT_NAME}-config.cmake.in
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}-${PRE_VERSION}
+  PATH_VARS INCLUDE_INSTALL_DIR)
+
+write_basic_package_version_file(
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    VERSION ${CPPLINQ_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME}-${CPPLINQ_VERSION})

--- a/README.md
+++ b/README.md
@@ -22,4 +22,10 @@ int computes_a_sum ()
 
 See the documentation: http://cpplinq.codeplex.com/documentation
 
+## Using the library with CMake
+The library is header-only, but still provides a package config module to allow easy usage of the library : 
 
+```cmake
+find_package(cpplinq 20150908 REQUIRED)
+include_directories(${cpplinq_INCLUDE_DIRS})
+```

--- a/cmake/modules/cpplinq-config.cmake.in
+++ b/cmake/modules/cpplinq-config.cmake.in
@@ -1,0 +1,6 @@
+set(CPPLINQ_VERSION @CPPLINQ_VERSION@)
+
+@PACKAGE_INIT@
+
+set_and_check(cpplinq_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+check_required_components(cpplinq)


### PR DESCRIPTION
Dear @mrange,

First thank you for the awesome work you did on cpplinq.

I'm sending you this PR as I'm currently integrating cpplinq in a project which is based on [CMake](http://www.cmake.org/) and [Hunter](https://github.com/ruslo/hunter).

The changes I brought here are only to provide a cmake config file when one install the library, it allows then to download and install the library automatically with the hunter package manager, as : 

``` cmake
hunter_add_package(cpplinq)
find_package(cpplinq 20150908 REQUIRED)
include_directories(${cpplinq_INCLUDE_DIRS})
```

This is possible with the [patched hunter here](https://github.com/daminetreg/hunter), but I'm doing a PR also to the official hunter which would then allow downloading any new official release made on github of cpplinq automatically.

I hope this change can be accepted, I'm available for any changes and improvements naturally. :smile:
Cheers,
