### PR TITLE
select with optional index parameter

### DIFF
--- a/CppLinq.Mini/CppLinq2015.Mini.vcxproj
+++ b/CppLinq.Mini/CppLinq2015.Mini.vcxproj
@@ -1,0 +1,164 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4CE7EBDE-D1A2-4B5D-853C-921668821E50}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>CppLinqMini</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CppLinq.Mini.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/CppLinq/cpplinq.hpp
+++ b/CppLinq/cpplinq.hpp
@@ -1925,6 +1925,11 @@ namespace cpplinq
 
         // -------------------------------------------------------------------------
 
+        template <typename F, typename... T1s, typename T2>
+        static auto choose (F&& f, std::tuple<T1s...>&&, T2&&) -> decltype (f (std::declval<T1s> ()...));
+        template <typename F, typename T1, typename... T2s>
+        static auto choose (F&& f, T1&&, std::tuple<T2s...>&&) -> decltype (f (std::declval<T2s> ()...));
+
         template<typename TRange, typename TPredicate>
         struct select_range : base_range
         {
@@ -1932,7 +1937,10 @@ namespace cpplinq
             static          TPredicate get_predicate ();
 
 
-            typedef        decltype (get_predicate ()(get_source ()))   raw_value_type  ;
+            typedef        decltype (choose (get_predicate (),
+                                             std::make_tuple (get_source ()),
+                                             std::make_tuple (get_source (), 0)))
+                                                                        raw_value_type  ;
             typedef        typename cleanup_type<raw_value_type>::type  value_type      ;
             typedef                 value_type const &                  return_type     ;
             enum
@@ -1944,31 +1952,35 @@ namespace cpplinq
             typedef                 TRange                              range_type      ;
             typedef                 TPredicate                          predicate_type  ;
 
-            range_type              range       ;
-            predicate_type          predicate   ;
+            range_type              range        ;
+            predicate_type          predicate    ;
 
-            opt<value_type>         cache_value ;
+            opt<value_type>         cache_value  ;
+            size_t                  current_index;
 
             CPPLINQ_INLINEMETHOD select_range (
                     range_type      range
                 ,   predicate_type  predicate
                 ) CPPLINQ_NOEXCEPT
-                :   range       (std::move (range))
-                ,   predicate   (std::move (predicate))
+                :   range        (std::move (range))
+                ,   predicate    (std::move (predicate))
+                ,   current_index(0)
             {
             }
 
             CPPLINQ_INLINEMETHOD select_range (select_range const & v)
-                :   range       (v.range)
-                ,   predicate   (v.predicate)
-                ,   cache_value (v.cache_value)
+                :   range        (v.range)
+                ,   predicate    (v.predicate)
+                ,   cache_value  (v.cache_value)
+                ,   current_index(v.current_index)
             {
             }
 
             CPPLINQ_INLINEMETHOD select_range (select_range && v) CPPLINQ_NOEXCEPT
-                :   range       (std::move (v.range))
-                ,   predicate   (std::move (v.predicate))
-                ,   cache_value (std::move (v.cache_value))
+                :   range        (std::move (v.range))
+                ,   predicate    (std::move (v.predicate))
+                ,   cache_value  (std::move (v.cache_value))
+                ,   current_index(std::move (v.current_index))
             {
             }
 
@@ -1988,13 +2000,25 @@ namespace cpplinq
             {
                 if (range.next ())
                 {
-                    cache_value = predicate (range.front ());
+                    cache_value = evaluate_predicate (predicate);
                     return true;
                 }
 
                 cache_value.clear ();
 
                 return false;
+            }
+
+            template<typename TPredicate_>
+            CPPLINQ_INLINEMETHOD auto evaluate_predicate(TPredicate_& pred) -> decltype (pred (range.front ()))
+            {
+                return pred (range.front ());
+            }
+
+            template<typename TPredicate_, int = 0 /* VisualStudio Workaround (http://stackoverflow.com/a/28204207/3647361) */>
+            CPPLINQ_INLINEMETHOD auto evaluate_predicate(TPredicate_& pred) -> decltype (pred (range.front (), 0))
+            {
+                return pred (range.front (), current_index++);
             }
         };
 

--- a/CppLinq2015.UnitTest/CodeCoverage.runsettings
+++ b/CppLinq2015.UnitTest/CodeCoverage.runsettings
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- File name extension must be .runsettings -->
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+                <Configuration>
+                    <CodeCoverage>
+                        <!--
+Additional paths to search for .pdb (symbol) files. Symbols must be found for modules to be instrumented.
+If .pdb files are in the same folder as the .dll or .exe files, they are automatically found. Otherwise, specify them here.
+Note that searching for symbols increases code coverage runtime. So keep this small and local.
+-->
+                        <!--
+            <SymbolSearchPaths>
+                   <Path>C:\Users\User\Documents\Visual Studio 2012\Projects\ProjectX\bin\Debug</Path>
+                   <Path>\\mybuildshare\builds\ProjectX</Path>
+            </SymbolSearchPaths>
+-->
+
+                        <!--
+About include/exclude lists:
+Empty "Include" clauses imply all; empty "Exclude" clauses imply none.
+Each element in the list is a regular expression (ECMAScript syntax). See http://msdn.microsoft.com/library/2k3te2cs.aspx.
+An item must first match at least one entry in the include list to be included.
+Included items must then not match any entries in the exclude list to remain included.
+-->
+
+                        <!-- Match assembly file paths: -->
+                        <ModulePaths>
+                            <Include>
+                                <ModulePath>.*\.dll$</ModulePath>
+                                <ModulePath>.*\.exe$</ModulePath>
+                            </Include>
+                            <Exclude>
+                                <ModulePath>.*CPPUnitTestFramework.*</ModulePath>
+                            </Exclude>
+                        </ModulePaths>
+
+                        <!-- Match fully qualified names of functions: -->
+                        <!-- (Use "\." to delimit namespaces in C# or Visual Basic, "::" in C++.)  -->
+                        <Functions>
+                            <Exclude>
+                                <Function>^Fabrikam\.UnitTest\..*</Function>
+                                <Function>^std::.*</Function>
+                                <Function>^ATL::.*</Function>
+                                <Function>.*::__GetTestMethodInfo.*</Function>
+                                <Function>^Microsoft::VisualStudio::CppCodeCoverageFramework::.*</Function>
+                                <Function>^Microsoft::VisualStudio::CppUnitTestFramework::.*</Function>
+                                <Function>^cpplinq::.*::what$</Function>
+                            </Exclude>
+                        </Functions>
+
+                        <!-- Match attributes on any code element: -->
+                        <Attributes>
+                            <Exclude>
+                                <!-- Don’t forget "Attribute" at the end of the name -->
+                                <Attribute>^System.Diagnostics.DebuggerHiddenAttribute$</Attribute>
+                                <Attribute>^System.Diagnostics.DebuggerNonUserCodeAttribute$</Attribute>
+                                <Attribute>^System.Runtime.CompilerServices.CompilerGeneratedAttribute$</Attribute>
+                                <Attribute>^System.CodeDom.Compiler.GeneratedCodeAttribute$</Attribute>
+                                <Attribute>^System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
+                            </Exclude>
+                        </Attributes>
+
+                        <!-- Match the path of the source files in which each method is defined: -->
+                        <Sources>
+                            <Exclude>
+                                <Source>.*\\atlmfc\\.*</Source>
+                                <Source>.*\\vctools\\.*</Source>
+                                <Source>.*\\public\\sdk\\.*</Source>
+                                <Source>.*\\microsoft sdks\\.*</Source>
+                                <Source>.*\\vc\\include\\.*</Source>
+                                <Source>.*\\cpplinq\\Test\\.*</Source>
+                                <Source>.*\\cpplinq\\CppLinq2013\.UnitTest\\.*</Source>
+                            </Exclude>
+                        </Sources>
+
+                        <!-- Match the company name property in the assembly: -->
+                        <CompanyNames>
+                            <Exclude>
+                                <CompanyName>.*microsoft.*</CompanyName>
+                            </Exclude>
+                        </CompanyNames>
+
+                        <!-- Match the public key token of a signed assembly: -->
+                        <PublicKeyTokens>
+                            <!-- Exclude Visual Studio extensions: -->
+                            <Exclude>
+                                <PublicKeyToken>^B77A5C561934E089$</PublicKeyToken>
+                                <PublicKeyToken>^B03F5F7F11D50A3A$</PublicKeyToken>
+                                <PublicKeyToken>^31BF3856AD364E35$</PublicKeyToken>
+                                <PublicKeyToken>^89845DCD8080CC91$</PublicKeyToken>
+                                <PublicKeyToken>^71E9BCE111E9429C$</PublicKeyToken>
+                                <PublicKeyToken>^8F50407C4E9E73B6$</PublicKeyToken>
+                                <PublicKeyToken>^E361AF139669C375$</PublicKeyToken>
+                            </Exclude>
+                        </PublicKeyTokens>
+
+
+                        <!-- We recommend you do not change the following values: -->
+                        <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+                        <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+                        <CollectFromChildProcesses>True</CollectFromChildProcesses>
+                        <CollectAspDotNet>False</CollectAspDotNet>
+
+                    </CodeCoverage>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>

--- a/CppLinq2015.UnitTest/CppLinq2015.UnitTest.vcxproj
+++ b/CppLinq2015.UnitTest/CppLinq2015.UnitTest.vcxproj
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{081E2554-9A17-45E3-9264-DC677FCE8DA2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>CppLinq2015UnitTest</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="CppLinqTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="CodeCoverage.runsettings" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/CppLinq2015.UnitTest/CppLinq2015.UnitTest.vcxproj.filters
+++ b/CppLinq2015.UnitTest/CppLinq2015.UnitTest.vcxproj.filters
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="stdafx.cpp" />
+    <ClCompile Include="CppLinqTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="CodeCoverage.runsettings" />
+  </ItemGroup>
+</Project>

--- a/CppLinq2015.UnitTest/CppLinqTest.cpp
+++ b/CppLinq2015.UnitTest/CppLinqTest.cpp
@@ -1,0 +1,36 @@
+// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+#include "stdafx.h"
+#include "CppUnitTest.h"
+// ----------------------------------------------------------------------------------------------
+// In order to suppress code coverage of assert macros
+#define CPPLINQ_ASSERT(expr)
+// ----------------------------------------------------------------------------------------------
+#include "../Test/CppLinqTests.hpp"
+// ----------------------------------------------------------------------------------------------
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+// ----------------------------------------------------------------------------------------------
+namespace CppLinq2013UnitTest
+{
+    TEST_CLASS(CppLinqTest)
+    {
+    public:
+
+        TEST_METHOD(RunTestSuite)
+        {
+            auto failures_detected = run_all_tests (false);
+            Assert::AreEqual (false, failures_detected);
+        }
+
+    };
+}
+// ----------------------------------------------------------------------------------------------

--- a/CppLinq2015.UnitTest/stdafx.cpp
+++ b/CppLinq2015.UnitTest/stdafx.cpp
@@ -1,0 +1,13 @@
+// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+#include "stdafx.h"
+// ----------------------------------------------------------------------------------------------

--- a/CppLinq2015.UnitTest/stdafx.h
+++ b/CppLinq2015.UnitTest/stdafx.h
@@ -1,0 +1,29 @@
+// ----------------------------------------------------------------------------------------------
+// Copyright (c) Mårten Rånge.
+// ----------------------------------------------------------------------------------------------
+// This source code is subject to terms and conditions of the Microsoft Public License. A
+// copy of the license can be found in the License.html file at the root of this distribution.
+// If you cannot locate the  Microsoft Public License, please send an email to
+// dlr@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
+//  by the terms of the Microsoft Public License.
+// ----------------------------------------------------------------------------------------------
+// You must not remove this notice, or any other, from this software.
+// ----------------------------------------------------------------------------------------------
+#pragma once
+// ----------------------------------------------------------------------------------------------
+#include <stdio.h>
+// ----------------------------------------------------------------------------------------------
+#include <algorithm>
+#include <chrono>
+#include <cassert>
+#include <climits>
+#include <exception>
+#include <iterator>
+#include <list>
+#include <map>
+#include <numeric>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <vector>
+// ----------------------------------------------------------------------------------------------

--- a/CppLinq2015.sln
+++ b/CppLinq2015.sln
@@ -1,0 +1,53 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30110.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CppLinq2015", "Test\CppLinq2015.vcxproj", "{B2C5078E-E859-4BF8-A799-75653FE524AB}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CppLinq2015.Mini", "CppLinq.Mini\CppLinq2015.Mini.vcxproj", "{4CE7EBDE-D1A2-4B5D-853C-921668821E50}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4203A08B-EAD5-4C1C-98AA-508D6A74CEAC}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CppLinq2015.UnitTest", "CppLinq2015.UnitTest\CppLinq2015.UnitTest.vcxproj", "{081E2554-9A17-45E3-9264-DC677FCE8DA2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Debug|Win32.Build.0 = Debug|Win32
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Debug|x64.ActiveCfg = Debug|x64
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Debug|x64.Build.0 = Debug|x64
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Release|Win32.ActiveCfg = Release|Win32
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Release|Win32.Build.0 = Release|Win32
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Release|x64.ActiveCfg = Release|x64
+		{B2C5078E-E859-4BF8-A799-75653FE524AB}.Release|x64.Build.0 = Release|x64
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Debug|Win32.ActiveCfg = Debug|Win32
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Debug|Win32.Build.0 = Debug|Win32
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Debug|x64.ActiveCfg = Debug|x64
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Debug|x64.Build.0 = Debug|x64
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Release|Win32.ActiveCfg = Release|Win32
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Release|Win32.Build.0 = Release|Win32
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Release|x64.ActiveCfg = Release|x64
+		{4CE7EBDE-D1A2-4B5D-853C-921668821E50}.Release|x64.Build.0 = Release|x64
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Debug|Win32.ActiveCfg = Debug|Win32
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Debug|Win32.Build.0 = Debug|Win32
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Debug|x64.ActiveCfg = Debug|x64
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Debug|x64.Build.0 = Debug|x64
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Release|Win32.ActiveCfg = Release|Win32
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Release|Win32.Build.0 = Release|Win32
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Release|x64.ActiveCfg = Release|x64
+		{081E2554-9A17-45E3-9264-DC677FCE8DA2}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Test/CppLinq2015.vcxproj
+++ b/Test/CppLinq2015.vcxproj
@@ -1,0 +1,170 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B2C5078E-E859-4BF8-A799-75653FE524AB}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>CppLinq</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\$(Configuration)\</OutDir>
+    <IntDir>Intermediate2015\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\CppLinq\cpplinq.hpp" />
+    <ClInclude Include="CppLinqTests.hpp" />
+    <ClInclude Include="stdafx.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CppLinq.cpp" />
+    <ClCompile Include="stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="TODO.txt" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -867,8 +867,8 @@ namespace
         }
 
         {
-            auto customers = empty<customer>() >> to_list ();
-            TEST_ASSERT (0U, customers.size ());
+            auto customers_list = empty<customer>() >> to_list ();
+            TEST_ASSERT (0U, customers_list.size ());
         }
 
     }
@@ -2603,9 +2603,9 @@ namespace
 
         // concat two non-empty ranges
         {
-            int set1[] = {0,1,2,3,4,5};
-            int set2[] = {6,7,8,9};
-            auto result = from_array (set1) >> concat (from_array (set2)) >> to_vector ();
+            int set3[] = {0,1,2,3,4,5};
+            int set4[] = {6,7,8,9};
+            auto result = from_array (set3) >> concat (from_array (set4)) >> to_vector ();
             TEST_ASSERT (10U, result.size ());
             for (auto i = 0U; i < 10 && i < result.size (); ++i)
             {

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -1772,6 +1772,18 @@ namespace
 
             TEST_ASSERT (0U, select_many_result.size ());
         }
+
+        {
+            std::vector<std::pair<size_t, char>> select_many_result =
+                    from_iterators (customers, customers)
+                >>  select_many([](customer const & c, std::size_t index) {return from(c.last_name)
+                                                                               >> select([index](char c) {return std::make_pair(index, c); }); })
+                >>  to_vector()
+                ;
+
+            TEST_ASSERT (0U, select_many_result.size ());
+        }
+
         {
             std::vector<char> expected;
             for (auto customer : customers)
@@ -1801,6 +1813,45 @@ namespace
             }
         }
 
+        {
+            std::vector<char> expected;
+            for (auto customer : customers)
+            {
+                expected.insert (
+                        expected.end ()
+                    ,   customer.last_name.begin ()
+                    ,   customer.last_name.end ()
+                    );
+            }
+
+            std::vector<std::pair<std::size_t, char>> select_many_result =
+                    from_array (customers)
+                >>  select_many([](customer const & c, std::size_t index) {return from(c.last_name)
+                                                                               >> select([index](char c) {return std::make_pair(index, c); }); })
+                >>  to_vector()
+                ;
+
+            std::size_t group = -1;
+            if (TEST_ASSERT (expected.size (), select_many_result.size ()))
+            {
+                for (std::size_t index = 0U; index < expected.size (); ++index)
+                {
+                    if (TEST_ASSERT (expected[index], select_many_result[index].second))
+                    {
+                        if (expected[index] >= 'A' && expected[index] <= 'Z') group++; //every name begins with an upper case character
+
+                        if (!TEST_ASSERT (group, select_many_result[index].first))
+                        {
+                            PRINT_INDEX (index);
+                        }
+                    }
+                    else
+                    {
+                        PRINT_INDEX (index);
+                    }
+                }
+            }
+        }
     }
 
     void test_orderby ()

--- a/Test/CppLinqTests.hpp
+++ b/Test/CppLinqTests.hpp
@@ -1626,6 +1626,11 @@ namespace
         }
 
         {
+            std::vector<double> select_result = from (empty_vector) >> select ([](int i, std::size_t index){return 1.0*i*index;}) >> to_vector ();
+            TEST_ASSERT (0U, select_result.size ());
+        }
+
+        {
             std::vector<std::size_t> select_result =
                     from_array (customers)
                 >>  select ([](customer const & c){return c.id;})
@@ -1646,6 +1651,26 @@ namespace
             TEST_ASSERT (count_of_customers, select_result.size ());
         }
 
+        {
+            std::vector<std::pair<std::size_t, std::size_t>> select_result =
+                    from_array (customers)
+                >>  select ([](customer const & c, std::size_t index){return std::make_pair(c.id, index);})
+                >>  to_vector ()
+                ;
+
+            std::size_t index = 0U;
+            for (auto sz : select_result)
+            {
+                if (!TEST_ASSERT (customers[index].id, sz.first) || !TEST_ASSERT (index, sz.second))
+                {
+                    PRINT_INDEX (index);
+                }
+
+                ++index;
+            }
+
+            TEST_ASSERT (count_of_customers, select_result.size ());
+        }
     }
 
     void test_join ()


### PR DESCRIPTION
I implemented the second overload of the select operator which takes the index of the current element in the sequence.

https://msdn.microsoft.com/en-us/library/bb534869%28v=vs.110%29.aspx

Example:

```
std::vector<std::string> str = { "Value1", "Value2", "Value3" };
from(str)
        >> select([](auto&& s, auto&& i) { return std::make_pair(i, s); })
        >> for_each([](auto&& s) { std::cout << s.first << " = " << s.second << "\n"; });
```

prints

```
0 = Value1
1 = Value2
2 = Value3
```
